### PR TITLE
Issue #32: Adding basic CI for publishing to crates.io based on tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,27 @@
+on:
+  push:
+    # Pattern matched against refs/tags
+    tags:        
+      - '*'           # Push events to every tag not containing /
+  workflow_dispatch:
+
+name: Publish
+
+jobs:
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+           
+      - run: cargo publish --token ${CRATES_TOKEN}
+        env:
+          CRATES_TOKEN: ${{ secrets.CRATES_TOKEN }}


### PR DESCRIPTION
Addresses #32 I added a crates.io key to the actions secret keys

Workflow to publish should be something like  

- Use [cargo-bump](https://crates.io/crates/cargo-bump) to bump the version number and to git tag the release 

```bash
cargo bump minor — git-tag
```

- push release tag to git 

```bash
git push — follow-tags
```

Haven't tested this yet but will do next week