### PR TITLE
Publish to PyPI and TestPyPI

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -221,7 +221,7 @@ jobs:
       - name: Publish to TestPyPI
         uses: PyO3/maturin-action@v1
         env:
-          MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+          MATURIN_PYPI_TOKEN: ${{ secrets.TESTPYPI_API_TOKEN }}
         with:
           command: upload
-          args: --non-interactive --skip-existing wheels-*/* --repository-url https://test.pypi.org/legacy/
+          args: --non-interactive --skip-existing --repository-url="https://test.pypi.org/legacy" wheels-*/*

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -211,23 +211,17 @@ jobs:
 
   publish_test:
     name: Release
+    runs-on: ubuntu-latest
     # TODO: add re-enable manylinux once earlier step is fixed
     # needs: [linux, musllinux, windows, macos, sdist]
     needs: [linux, windows, macos, sdist]
     environment: testpypi
-    permissions:
-      id-token: write
-    runs-on: ubuntu-latest
-
     steps:
       - uses: actions/download-artifact@v4
+      - name: Publish to TestPyPI
+        uses: PyO3/maturin-action@v1
+        env:
+          MATURIN_PYPI_TOKEN: ${{ secrets.TESTPYPI_API_TOKEN }}
         with:
-          name: artifact
-          path: dist
-
-      - uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          repository-url: https://test.pypi.org/legacy/
-          # Only skip existing distributions on testpypi (not on pypi).
-          # See https://github.com/pypa/gh-action-pypi-publish?tab=readme-ov-file#tolerating-release-package-file-duplicates
-          skip-existing: true
+          command: upload
+          args: --non-interactive --skip-existing --repository-url="https://test.pypi.org/legacy" wheels-*/*

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -211,17 +211,23 @@ jobs:
 
   publish_test:
     name: Release
-    runs-on: ubuntu-latest
     # TODO: add re-enable manylinux once earlier step is fixed
     # needs: [linux, musllinux, windows, macos, sdist]
     needs: [linux, windows, macos, sdist]
     environment: testpypi
+    permissions:
+      id-token: write
+    runs-on: ubuntu-latest
+
     steps:
       - uses: actions/download-artifact@v4
-      - name: Publish to TestPyPI
-        uses: PyO3/maturin-action@v1
-        env:
-          MATURIN_PYPI_TOKEN: ${{ secrets.TESTPYPI_API_TOKEN }}
         with:
-          command: upload
-          args: --non-interactive --skip-existing --repository-url="https://test.pypi.org/legacy" wheels-*/*
+          name: artifact
+          path: dist
+
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          # Only skip existing distributions on testpypi (not on pypi).
+          # See https://github.com/pypa/gh-action-pypi-publish?tab=readme-ov-file#tolerating-release-package-file-duplicates
+          skip-existing: true

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -214,7 +214,9 @@ jobs:
     runs-on: ubuntu-latest
     # TODO: add re-enable manylinux once earlier step is fixed
     # needs: [linux, musllinux, windows, macos, sdist]
-    needs: [linux, windows, macos, sdist]
+    # needs: [linux, windows, macos, sdist]
+    # TODO: Use fasting build during testing
+    needs: [macos, sdist]
     environment: testpypi
     steps:
       - uses: actions/download-artifact@v4

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -195,7 +195,9 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     if: "startsWith(github.ref, 'refs/tags/')"
-    needs: [linux, musllinux, windows, macos, sdist]
+    # TODO: add re-enable manylinux once earlier step is fixed
+    # needs: [linux, musllinux, windows, macos, sdist]
+    needs: [linux, windows, macos, sdist]
     environment: release
     steps:
       - uses: actions/download-artifact@v4
@@ -210,7 +212,9 @@ jobs:
   publish_test:
     name: Release
     runs-on: ubuntu-latest
-    needs: [linux, musllinux, windows, macos, sdist]
+    # TODO: add re-enable manylinux once earlier step is fixed
+    # needs: [linux, musllinux, windows, macos, sdist]
+    needs: [linux, windows, macos, sdist]
     environment: testpypi
     steps:
       - uses: actions/download-artifact@v4

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -77,41 +77,56 @@ jobs:
           path: dist
 
   # TODO: fix CI to run with manylinux: musllinux_1_2
-  # musllinux:
-  #   runs-on: ${{ matrix.platform.runner }}
-  #   strategy:
-  #     matrix:
-  #       platform:
-  #         - runner: ubuntu-latest
-  #           target: x86_64
-  #         - runner: ubuntu-latest
-  #           target: x86
-  #         - runner: ubuntu-latest
-  #           target: aarch64
-  #         - runner: ubuntu-latest
-  #           target: armv7
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: actions/setup-python@v5
-  #       with:
-  #         python-version: ${{ env.PYTHON_VERSION }}
-  #     - name: Build wheels
-  #       uses: PyO3/maturin-action@v1
-  #       with:
-  #         target: ${{ matrix.platform.target }}
-  #         args: --release --out dist --find-interpreter --manifest-path popgetter_py/Cargo.toml
-  #         sccache: "true"
-  #         before-script-linux: |
-  #             # TODO: update with package instructions specific to target for openssl
-  #             # See example: https://github.com/PyO3/maturin-action/discussions/162#discussioncomment-7978369
-  #             sudo apt-get update
-  #             sudo apt-get install -y pkg-config libssl-dev
-  #         manylinux: musllinux_1_2
-  #     - name: Upload wheels
-  #       uses: actions/upload-artifact@v4
-  #       with:
-  #         name: wheels-musllinux-${{ matrix.platform.target }}
-  #         path: dist
+  # -- TESTING MANYLINUX CONFIGURATION --
+
+  musllinux:
+    runs-on: ${{ matrix.platform.runner }}
+    strategy:
+      matrix:
+        platform:
+          - runner: ubuntu-latest
+            target: x86_64
+          - runner: ubuntu-latest
+            target: x86
+          - runner: ubuntu-latest
+            target: aarch64
+          - runner: ubuntu-latest
+            target: armv7
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.platform.target }}
+          args: --release --out dist --find-interpreter --manifest-path popgetter_py/Cargo.toml
+          sccache: "true"
+          before-script-linux: |
+              # TODO: update with package instructions specific to target for openssl
+              # See example: https://github.com/PyO3/maturin-action/discussions/162#discussioncomment-7978369
+              sudo apt-get update
+              sudo apt-get install -y pkg-config libssl-dev
+              # For debug purposes:
+              sudo apt show libssl-dev
+              sudo apt-get install -y apt-file
+              sudo apt-file update
+              sudo apt-file list libssl-dev
+              uname -a
+              # Build is failing on 
+              # error: failed to run custom build command for `openssl-sys v0.9.102`
+          docker-options: >
+            --env OPENSSL_INCLUDE_DIR=/usr/include/openssl
+            --env PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu
+          manylinux: musllinux_1_2
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-musllinux-${{ matrix.platform.target }}
+          path: dist
+
+  # -- END OF MANYLINUX CONFIGURATION --
 
   windows:
     runs-on: ${{ matrix.platform.runner }}
@@ -195,7 +210,7 @@ jobs:
     name: Release to PyPI
     runs-on: ubuntu-latest
     # TODO Re-enable after first successful run 
-    # if: "startsWith(github.ref, 'refs/tags/')"
+    if: "startsWith(github.ref, 'refs/tags/')"
     # TODO: add re-enable manylinux once earlier step is fixed
     # needs: [linux, musllinux, windows, macos, sdist]
     needs: [linux, windows, macos, sdist]
@@ -214,8 +229,8 @@ jobs:
     name: Release to TestPyPI
     runs-on: ubuntu-latest
     # TODO: add re-enable manylinux once earlier step is fixed
-    # needs: [linux, musllinux, windows, macos, sdist]
-    needs: [linux, windows, macos, sdist]
+    needs: [linux, musllinux, windows, macos, sdist]
+    # needs: [linux, windows, macos, sdist]
     environment: testpypi
     steps:
       - uses: actions/download-artifact@v4

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -191,18 +191,33 @@ jobs:
           name: wheels-sdist
           path: dist
 
-  # TODO: uncomment for release to PyPI
-  # release:
-  #   name: Release
-  #   runs-on: ubuntu-latest
-  #   if: "startsWith(github.ref, 'refs/tags/')"
-  #   needs: [linux, musllinux, windows, macos, sdist]
-  #   steps:
-  #     - uses: actions/download-artifact@v4
-  #     - name: Publish to PyPI
-  #       uses: PyO3/maturin-action@v1
-  #       env:
-  #         MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
-  #       with:
-  #         command: upload
-  #         args: --non-interactive --skip-existing wheels-*/*
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    if: "startsWith(github.ref, 'refs/tags/')"
+    needs: [linux, musllinux, windows, macos, sdist]
+    environment: release
+    steps:
+      - uses: actions/download-artifact@v4
+      - name: Publish to PyPI
+        uses: PyO3/maturin-action@v1
+        env:
+          MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+        with:
+          command: upload
+          args: --non-interactive --skip-existing wheels-*/*
+
+  publish_test:
+    name: Release
+    runs-on: ubuntu-latest
+    needs: [linux, musllinux, windows, macos, sdist]
+    environment: testpypi
+    steps:
+      - uses: actions/download-artifact@v4
+      - name: Publish to TestPyPI
+        uses: PyO3/maturin-action@v1
+        env:
+          MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+        with:
+          command: upload
+          args: --non-interactive --skip-existing wheels-*/* --repository-url https://test.pypi.org/legacy/

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -192,9 +192,10 @@ jobs:
           path: dist
 
   release:
-    name: Release
+    name: Release to PyPI
     runs-on: ubuntu-latest
-    if: "startsWith(github.ref, 'refs/tags/')"
+    # TODO Re-enable after first successful run 
+    # if: "startsWith(github.ref, 'refs/tags/')"
     # TODO: add re-enable manylinux once earlier step is fixed
     # needs: [linux, musllinux, windows, macos, sdist]
     needs: [linux, windows, macos, sdist]
@@ -210,13 +211,11 @@ jobs:
           args: --non-interactive --skip-existing wheels-*/*
 
   publish_test:
-    name: Release
+    name: Release to TestPyPI
     runs-on: ubuntu-latest
     # TODO: add re-enable manylinux once earlier step is fixed
     # needs: [linux, musllinux, windows, macos, sdist]
-    # needs: [linux, windows, macos, sdist]
-    # TODO: Use fasting build during testing
-    needs: [macos, sdist]
+    needs: [linux, windows, macos, sdist]
     environment: testpypi
     steps:
       - uses: actions/download-artifact@v4

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -79,52 +79,52 @@ jobs:
   # TODO: fix CI to run with manylinux: musllinux_1_2
   # -- TESTING MANYLINUX CONFIGURATION --
 
-  musllinux:
-    runs-on: ${{ matrix.platform.runner }}
-    strategy:
-      matrix:
-        platform:
-          - runner: ubuntu-latest
-            target: x86_64
-          - runner: ubuntu-latest
-            target: x86
-          - runner: ubuntu-latest
-            target: aarch64
-          - runner: ubuntu-latest
-            target: armv7
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-      - name: Build wheels
-        uses: PyO3/maturin-action@v1
-        with:
-          target: ${{ matrix.platform.target }}
-          args: --release --out dist --find-interpreter --manifest-path popgetter_py/Cargo.toml
-          sccache: "true"
-          before-script-linux: |
-              # TODO: update with package instructions specific to target for openssl
-              # See example: https://github.com/PyO3/maturin-action/discussions/162#discussioncomment-7978369
-              sudo apt-get update
-              sudo apt-get install -y pkg-config libssl-dev
-              # For debug purposes:
-              sudo apt show libssl-dev
-              sudo apt-get install -y apt-file
-              sudo apt-file update
-              sudo apt-file list libssl-dev
-              uname -a
-              # Build is failing on 
-              # error: failed to run custom build command for `openssl-sys v0.9.102`
-          docker-options: >
-            --env OPENSSL_INCLUDE_DIR=/usr/include/openssl
-            --env PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu
-          manylinux: musllinux_1_2
-      - name: Upload wheels
-        uses: actions/upload-artifact@v4
-        with:
-          name: wheels-musllinux-${{ matrix.platform.target }}
-          path: dist
+  # musllinux:
+  #   runs-on: ${{ matrix.platform.runner }}
+  #   strategy:
+  #     matrix:
+  #       platform:
+  #         - runner: ubuntu-latest
+  #           target: x86_64
+  #         - runner: ubuntu-latest
+  #           target: x86
+  #         - runner: ubuntu-latest
+  #           target: aarch64
+  #         - runner: ubuntu-latest
+  #           target: armv7
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: actions/setup-python@v5
+  #       with:
+  #         python-version: ${{ env.PYTHON_VERSION }}
+  #     - name: Build wheels
+  #       uses: PyO3/maturin-action@v1
+  #       with:
+  #         target: ${{ matrix.platform.target }}
+  #         args: --release --out dist --find-interpreter --manifest-path popgetter_py/Cargo.toml
+  #         sccache: "true"
+  #         before-script-linux: |
+  #             # TODO: update with package instructions specific to target for openssl
+  #             # See example: https://github.com/PyO3/maturin-action/discussions/162#discussioncomment-7978369
+  #             sudo apt-get update
+  #             sudo apt-get install -y pkg-config libssl-dev
+  #             # For debug purposes:
+  #             sudo apt show libssl-dev
+  #             sudo apt-get install -y apt-file
+  #             sudo apt-file update
+  #             sudo apt-file list libssl-dev
+  #             uname -a
+  #             # Build is failing on 
+  #             # error: failed to run custom build command for `openssl-sys v0.9.102`
+  #         docker-options: >
+  #           --env OPENSSL_INCLUDE_DIR=/usr/include/openssl
+  #           --env PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu
+  #         manylinux: musllinux_1_2
+  #     - name: Upload wheels
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: wheels-musllinux-${{ matrix.platform.target }}
+  #         path: dist
 
   # -- END OF MANYLINUX CONFIGURATION --
 
@@ -229,8 +229,8 @@ jobs:
     name: Release to TestPyPI
     runs-on: ubuntu-latest
     # TODO: add re-enable manylinux once earlier step is fixed
-    needs: [linux, musllinux, windows, macos, sdist]
-    # needs: [linux, windows, macos, sdist]
+    # needs: [linux, musllinux, windows, macos, sdist]
+    needs: [linux, windows, macos, sdist]
     environment: testpypi
     steps:
       - uses: actions/download-artifact@v4

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -209,7 +209,6 @@ jobs:
   release:
     name: Release to PyPI
     runs-on: ubuntu-latest
-    # TODO Re-enable after first successful run 
     if: "startsWith(github.ref, 'refs/tags/')"
     # TODO: add re-enable manylinux once earlier step is fixed
     # needs: [linux, musllinux, windows, macos, sdist]


### PR DESCRIPTION
This PR reinstates the CD process to publish the Python package to PyPI and TestPyPI. Packages will be published:
- **PyPI**: when tagged commits are pushed to main
- **TestPyPI**: on every commit to a pull request (though version numbers are not automatically bumped and the CD will not overwrite existing published packages)

Most common platform and architecture combinations are supported:
- Windows, x64 and x86
- MacOS 13 on x86_64 and MacOS15 on aarch64
- Ubuntu, x64 and x86
- Source distribution

There are problems with the build for Linux on non-intel architecture, which will be described and dealt with in more detail here #96.

This PR contributes to #77