### PR TITLE
disable pip install for doc build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,6 +6,8 @@ build:
     python: "3.11"
     rust: "1.82"
   jobs:
+    - install:
+      - pip install "mkdocs-mermaid2-plugin>=1.2.1"
     pre_build:
       # Copy the README.md file of each package into the docs directory
       - cp popgetter-py/README.md docs/popgetter-py.md

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,7 +6,7 @@ build:
     python: "3.11"
     rust: "1.82"
   jobs:
-    - install:
+    install:
       - pip install "mkdocs-mermaid2-plugin>=1.2.1"
     pre_build:
       # Copy the README.md file of each package into the docs directory

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -15,9 +15,10 @@ build:
 mkdocs:
   configuration: mkdocs.yml
 
-python:
-  install:
-    - method: pip
-      path: popgetter-py
-      extra_requirements:
-        - docs
+# Not required? Currently we're not using any of the docstrings in the code
+# python:
+#   install:
+#     - method: pip
+#       path: popgetter-py
+#       extra_requirements:
+#         - docs


### PR DESCRIPTION
~~Testing this to see if it improves build time on RTDs~~

This reduces the docs build time to ~45 sec (from ~15 min). Installing the `popgetter-py` package was the slow step in then build, but having it installed is not currently needed for doc building purposes.